### PR TITLE
Update PASW 2012R2 index page

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -5,33 +5,38 @@ owner: Diego
 
 <strong><%= modified_date %></strong>
 
-<p class='note'><strong>Note:</strong> Elastic Runtime has been renamed Pivotal Application Service.</p>
+<p class='note'><strong>Note:</strong> Elastic Runtime has been renamed Pivotal Application Service. Runtime for Windows has been renamed Pivotal Application Service for Windows 2012R2.</p>
 
-This documentation describes how operators install and manage Windows [Diego cells](../concepts/architecture/index.html#diego-cell) in Pivotal Cloud Foundry (PCF) with PAS for Windows 2012R2 and how developers push .NET Framework applications to Windows cells.
+<p class='note'><strong>Note:</strong> PAS for Windows 2012R2 is provided for compatibility with Windows Server 2012 R2 only. For Pivotal's fully featured .NET / Windows product, please see [Pivotal Application Service for Windows](https://docs.pivotal.io/pivotalcf/windows). Please refer to the [limitations](#limitations) of this product below if you require Windows Server 2012 R2.</p>
 
-Operators can install PAS for Windows 2012R2 on Microsoft Azure, VMware vSphere, Amazon Web Services (AWS), or Google Cloud Platform (GCP).
 
 ## <a id='overview'></a>Overview
 
-Operators who want to enable developers to push .NET Framework applications can deploy Windows-based Diego cells in PCF with the PAS for Windows 2012R2 tile.
+Pivotal Application Service for Windows 2012R2 enables PCF to host full .NET Framework and Windows-based applications, using Windows Server 2012 R2 and the IronFrame containerization framework. For Windows Server 2016 support, see [Pivotal Application Service for Windows](https://docs.pivotal.io/pivotalcf/windows).
 
-Deploying this tile creates a separate BOSH deployment populated with the Garden-Windows BOSH release, which runs on a Windows cell built from a Windows Server 2012R2 stemcell. This lets PCF deploy Windows-based Diego cells in addition to Linux-based Diego cells.
+By deploying the PAS for Windows 2012R2 tile in the Ops Manager Installation Dashboard, operators can provision, operate, and manage Diego cells based on Windows Server 2012 R2. Once deployed, developers can then push .NET Framework applications to Windows [Diego cells](../concepts/architecture/index.html#diego-cell) using the [Cloud Foundry Command Line Interface](https://docs.pivotal.io/pivotalcf/cf-cli/) (cf CLI) and specifying the `windows2012R2` stack.
 
-Once the Windows cell is running and after developers build their applications, they can then specify the `windows2012R2` stack when pushing .NET Framework apps from the command line or PowerShell session. Using the Diego infrastructure, PCF passes the app to the Windows cell in the PAS for Windows 2012R2 deployment. The diagram below illustrates the process.
+Operators can install PAS for Windows 2012R2 on Microsoft Azure, VMware vSphere, Amazon Web Services (AWS), or Google Cloud Platform (GCP).
 
-<%= image_tag('windows-overview.png') %>
+For the PAS for Windows release notes, see the [Release Notes](release-notes.html) topic.
 
 ## <a id='requirements'></a> Requirements
 
-When configuring the Windows deployment, the minimum resource requirements for each Windows cell are as follows:
+To install the PAS for Windows 2012R2 tile, you must have:
 
-- Disk size: 64&nbsp;GB
-- Memory: 16&nbsp;GB
+* Any patch version of Ops Manager v2.1, deployed to vSphere, Amazon Web Services (AWS), Google Cloud Platform (GCP), or Microsoft Azure.
+
+* Any patch version of Pivotal Application Service (PAS) v2.1.
+
+* A Windows Server 2012R2 stemcell, which you can obtain by following the directions in [Downloading or Creating Windows Stemcells](./stemcells.html). By design, PAS for Windows 2012R2 only supports deployments based on Windows Server 2012 R2.
+
+The minimum recommended resource requirements for each Windows cell are the following:
+
+- Disk size: 64GB
+- Memory: 16GB
 - Number of CPUs: 4
 
-By design, PAS for Windows 2012R2 only supports deployments based on Windows Server 2012R2.
-
-Due to Microsoft's licensing requirements, operators must either bring their own licensed copies of Windows Server (for on-premise deployments) or pay the surcharges associated with Windows Server licensing determined by the IaaS provider on Azure, AWS, and GCP.
+Due to Microsoft’s licensing requirements, operators must use their own licensed copies of Windows Server for on-premise deployments (vSphere) or, for public IaaS deployments, pay the surcharges associated with Windows Server licensing determined by the public IaaS provider on Microsoft Azure, Amazon Web Services, and Google Cloud Platform.
 
 
 ## <a id='understand'></a>Understanding PAS for Windows 2012R2 ##
@@ -40,19 +45,19 @@ Due to Microsoft's licensing requirements, operators must either bring their own
 
 * <a href="windows-security.html" class="subnav">Understanding Stemcell Security</a>
 
-## <a id='install'></a>Installing PAS for Windows 2012R2 ##
+## <a id='install'></a>Installation Guide ##
 
 * <a href="./about-windows-stemcells.html">Using Windows Stemcells</a>
+
 * <a href="./deploy-windows.html" class="subnav">Deploying PAS for Windows 2012R2</a>
 
-## <a id="managing"></a>Managing Windows Cells
+## <a id="admin"></a>Admin Guide
 
 * <a href="./upgrade-windows.html" class="subnav">Upgrading Windows Cells</a>
 
 * <a href="./windows-troubleshooting.html" class="subnav">Troubleshooting Windows Cells</a>
 
-
-## <a id='dev'></a>Developing on Windows Cells
+## <a id='dev'></a>Developer Guide
 
 * <a href="push-windows-apps.html" class="subnav">Deploying .NET Framework Apps to Windows Cells</a>
 
@@ -61,58 +66,32 @@ Due to Microsoft's licensing requirements, operators must either bring their own
 
 Deployments of Windows Diego Cells with PAS for Windows 2012R2 have the following limitations:
 
-* Because of the process management characteristics of Windows Server 2012R2, Windows cells can host a maximum of 40 app instances per cell. Operators should take this density constraint into account when planning the sizes of their PAS for Windows 2012R2 deployments, in addition to CPU, disk, and memory needs.
+* Because of the process management characteristics of Windows Server 2012 R2, Windows cells can host a maximum of 40 app instances per cell. Operators should take this density constraint into account when planning the sizes of their PAS for Windows 2012R2 deployments, in addition to CPU, disk, and memory needs.
 
 * The following Cloud Foundry features are not supported by PAS for Windows 2012R2:
 
   - Diego SSH, i.e. the `cf ssh` command. This is due to limitations of the inherent file system isolation characteristics of Windows Server 2012R2.
   - Volume services. For mounting SMB shares, developers should access SMB volumes from their applications directly.
   - Container-to-container networking. The IronFrame library that provides container-like features on Windows Server 2012R2 does not support container networking. IronFrame binds virtual container ports to the host.
-
+  - Pushing docker or other OCI-compatible container images.
 
 * The following Windows technologies are not supported by PAS for Windows 2012R2:
 
   - Active Directory Domain Services, i.e. joining Windows cells to an Active Directory domain.
   - Integrated Windows Authentication. Instead, operators should deploy Active Directory Federation Services and the Pivotal SSO tile to enable OAuth-based authentication.
 
-* You cannot push Docker or other OCI-compatible images to Windows 2012R2 cells.
-
-Except for the inability to host OCI-compatible images, [PAS for Windows](../windows/index.html) does not have any of the limitations above.
+Please consider [Pivotal Application Service for Windows](https://docs.pivotal.io/pivotalcf/windows), which has fewer limitations and will continue to receive additional platform features.
 
 ## <a id='issues'></a>Known Issues
 
 PAS for Windows 2012R2 has the following known issues:
 
-* In the PAS for Windows 2012R2 tile **Credentials** tab, the `vcap` credentials that appear when you click **VM Credentials** > **Link to Credential** do not apply to Windows cells, since they do not yet have a vcap user.
+* In the PAS for Windows 2012R2 tile **Credentials** tab, the `vcap` credentials that appear when you click **VM Credentials** > **Link to Credential** do not apply to Windows cells, since they do not yet have a vcap user on the host. To establish access for an `Administrator` user, please see the **VM Options** tab to specify a password for that user.
 
-* Under **VM Options** > **Manage Administrator Password** > **Set the password**, setting the `Administrator` user password has the following issues:
-
-  - For Azure-hosted deployments: Setting the password directly does not yet work. All passwords for the user called `Administrator` will be randomized by default. Please use the following workarounds to access the VM directly:
-
-      - Create a user in the Azure cloud management console.
-      - Use the **Enable SSH** feature.
-
-
-  - For GCP-hosted deployments: Setting the password directly does not yet work. Please use the following workarounds to access the VM:
-
-      - Create a user in the GCP cloud management console.
-      - Use the **Enable SSH** feature.
-
-      - For AWS and vSphere deployments: You can set a password for the user called `Administrator`, but the password must be 8-14 characters and is limited to letters, numbers, and the `!` character, which is the only working special character.
-
-      - For all IaaSes, for stemcell versions 1200.5 and later, the password for the user called `Administrator` is randomized by default to provide additional security in production settings.
+* Under **VM Options** > **Manage Administrator Password** > **Set the password**, the password must be 8-14 characters and is limited to letters, numbers, and the `!` character, which is the only working special character.
 
 * The controls in the **Advanced Features** pane have no effect.
 
-* In the **Resource Config** pane, setting VM disk sizes has the following limitations. See the [Root Disk Sizing](./about-windows-stemcells.html#sizing) table for details:
-
-  - AWS: For stemcells earlier than 1200.9, setting disk size value has no effect. VM disks are 30 GB.
-
-  - GCP: Setting the disk size only works for values 50 GB or larger.
-
-  - vSphere: Setting disk size value has no effect. VM disks will match the disk size of the stemcell you create.
+* In the **Resource Config** pane, setting VM disk sizes has the following limitations. See the [Root Disk Sizing](./about-windows-stemcells.html#sizing) table for details.
 
 * When a PAS for Windows 2012R2 container shuts down, it may leave behind ghost connections and pending transactions that put the app in an inconsistent state. This is due to a known limitation of the IronFrame containerization framework. See the [Container Shutdown](./understand-windows.html#container-shutdown) section for details.
-
-[PAS for Windows](../windows/index.html) does not have any of the above issues.
-


### PR DESCRIPTION
- Used similar structure to PASW index page update
- Added note to encourage use of the new product, PASW
- Added general installation requirements
- Removed obsolete limitations
- Deferred root disk sizing limitations to stemcell page